### PR TITLE
Refresh access token when it has expired. Added old access token to callback.

### DIFF
--- a/src/Bearer.php
+++ b/src/Bearer.php
@@ -131,10 +131,19 @@ final class Bearer
      */
     private function renewAccessToken()
     {
-        $this->accessToken = $this->provider->getAccessToken('client_credentials');
+        $oldAccessToken = $this->accessToken;
+        $refreshToken = $this->accessToken ? $this->accessToken->getRefreshToken() : null;
+
+        if ($refreshToken) {
+            $this->accessToken = $this->provider->getAccessToken('refresh_token', [
+                'refresh_token' => $refreshToken,
+            ]);
+        } else {
+            $this->accessToken = $this->provider->getAccessToken('client_credentials');
+        }
 
         if ($this->tokenCallback) {
-            call_user_func($this->tokenCallback, $this->accessToken);
+            call_user_func($this->tokenCallback, $this->accessToken, $oldAccessToken);
         }
     }
 }


### PR DESCRIPTION
**Refresh access token when it has expired**

It will try to run `refresh_token` against refresh token if it is present and access token has expired.

**Added old access token to callback.**

I found it useful to know at certain situations which access token was updated, so I've added old access token as a second parameter of the callback.
